### PR TITLE
Added type=int to concurrency_count

### DIFF
--- a/axeman/core.py
+++ b/axeman/core.py
@@ -272,7 +272,7 @@ def main():
 
     parser.add_argument('-v', dest="verbose", action="store_true", help="Print out verbose/debug info")
 
-    parser.add_argument('-c', dest='concurrency_count', action='store', default=50, help="The number of concurrent downloads to run at a time")
+    parser.add_argument('-c', dest='concurrency_count', action='store', default=50, type=int, help="The number of concurrent downloads to run at a time")
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Currently if try to run it with a custom concurrency_count it will crash on line 104 because concurrency_count is a string.