### PR TITLE
Re-enabled the output directory functionality

### DIFF
--- a/axeman/core.py
+++ b/axeman/core.py
@@ -290,9 +290,9 @@ def main():
     logging.info("Starting...")
 
     if args.ctl_url:
-        loop.run_until_complete(retrieve_certificates(loop, url=args.ctl_url, ctl_offset=int(args.ctl_offset), concurrency_count=args.concurrency_count))
+        loop.run_until_complete(retrieve_certificates(loop, url=args.ctl_url, ctl_offset=int(args.ctl_offset), output_directory=args.output_dir, concurrency_count=args.concurrency_count))
     else:
-        loop.run_until_complete(retrieve_certificates(loop, concurrency_count=args.concurrency_count))
+        loop.run_until_complete(retrieve_certificates(loop, output_directory=args.output_dir, concurrency_count=args.concurrency_count))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
The -o flag did not work. By default all output is written to /tmp, which is now fixed by forwarding the command line arguments to the retrieve_certificates function.