### PR TITLE
Force construct to be 2.9.52

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ uvloop
 aiohttp
 aioprocessing
 PyOpenSSL
-construct
+construct==2.9.52


### PR DESCRIPTION
The newest version of construct (2.10.52) breaks axeman, it might be wise to pin 2.9.52 in the mainwhile.

2.10.52:
`ImportError: cannot import name 'Embedded'`