### PR TITLE
Update to work with new log_list.json endpoint

### DIFF
--- a/axeman/__init__.py
+++ b/axeman/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.14'
+__version__ = '1.15'
 
 if __name__ == "__main__":
     from .core import main

--- a/axeman/certlib.py
+++ b/axeman/certlib.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 from OpenSSL import crypto
 
-CTL_LISTS = 'https://www.gstatic.com/ct/log_list/v3/log_list.json'
+CTL_LISTS = 'https://www.gstatic.com/ct/log_list/v3/all_logs_list.json'
 
 CTL_INFO = "https://{}/ct/v1/get-sth"
 

--- a/axeman/certlib.py
+++ b/axeman/certlib.py
@@ -6,11 +6,11 @@ from collections import OrderedDict
 
 from OpenSSL import crypto
 
-CTL_LISTS = 'https://www.gstatic.com/ct/log_list/log_list.json'
+CTL_LISTS = 'https://www.gstatic.com/ct/log_list/v3/log_list.json'
 
-CTL_INFO = "http://{}/ct/v1/get-sth"
+CTL_INFO = "https://{}/ct/v1/get-sth"
 
-DOWNLOAD = "http://{}/ct/v1/get-entries?start={}&end={}"
+DOWNLOAD = "https://{}/ct/v1/get-entries?start={}&end={}"
 
 from construct import Struct, Byte, Int16ub, Int64ub, Enum, Bytes, Int24ub, this, GreedyBytes, GreedyRange, Terminated, Embedded
 
@@ -42,13 +42,15 @@ async def retrieve_all_ctls(session=None):
     async with session.get(CTL_LISTS) as response:
         ctl_lists = await response.json()
 
-        logs = ctl_lists['logs']
-
-        for log in logs:
-            if log['url'].endswith('/'):
-                log['url'] = log['url'][:-1]
-            owner = _get_owner(log, ctl_lists['operators'])
-            log['operated_by'] = owner
+        logs = []
+        for operator in ctl_lists['operators']:
+            owner = operator['name']
+            for log in operator['logs']:
+                log['url'] = log['url'].replace('https://','')
+                if log['url'].endswith('/'):
+                    log['url'] = log['url'][:-1]        
+                log['operated_by'] = owner
+                logs.append(log)
 
         return logs
 


### PR DESCRIPTION
Log list is now at https://www.gstatic.com/ct/log_list/v3/log_list.json and old url is no longer valid. JSON structure is different and urls contain "https://", so processing is updated to account for this.

Also, version bump.